### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,17 +34,18 @@ or with the Caddyfile:
 # globally
 {
 	acme_dns luadns {
-		api_key <your_luadns_email>
+		email <your_luadns_email>
 		api_key <your_luadns_api_key>
 	}
 }
 ```
-
+Note that the `dns_ttl` directive is required!
 ```Caddyfile
 # one site
 tls {
+	dns_ttl 5m
 	dns luadns {
-		api_key <your_luadns_email>
+		email <your_luadns_email>
 		api_key <your_luadns_api_key>
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/caddy-dns/luadns
+module github.com/dimitrovs/luadns
 
 go 1.21.0
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/dimitrovs/luadns
+module github.com/caddy-dns/luadns
 
 go 1.21.0
 

--- a/luadns.go
+++ b/luadns.go
@@ -47,7 +47,7 @@ func (p *Provider) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 					return d.Err("Email already set")
 				}
 				if d.NextArg() {
-					p.Provider.APIKey = d.Val()
+					p.Provider.Email = d.Val()
 				}
 				if d.NextArg() {
 					return d.ArgErr()


### PR DESCRIPTION
I finally got LuaDNS to work with Caddy for wildcard subdomains. The tricky part was adding the `dns_ttl` directive to the tls block.